### PR TITLE
Relocate gene names to the main thread.

### DIFF
--- a/public/scran/_utils_markers.js
+++ b/public/scran/_utils_markers.js
@@ -120,16 +120,8 @@ scran_utils_markers.fetchGroupResults = function(wasm, results, reloaded, rank_t
     stat_delta_d = reorder(results.delta_detected(group, 1));
   }
 
-  /** TODO: move this to the main thread to avoid having to 
-   * continually (un)serialize a large string array. */
-  var genes = scran_inputs.fetchGeneNames(wasm);
-  var new_genes = [];
-  for (const o of ordering) {
-      new_genes.push(genes[o]);
-  }
-
   return {
-    "genes": new_genes,
+    "ordering": ordering,
     "means": stat_mean,
     "detected": stat_detected,
     "lfc": stat_lfc,

--- a/public/scran/scranWorker.js
+++ b/public/scran/scranWorker.js
@@ -164,27 +164,16 @@ onmessage = function (msg) {
     });
   } else if (payload.type == "getGeneExpression") {
     loaded.then(wasm => {
-      let row = payload.payload.gene;
-      let row_idx = scran_inputs.fetchGeneNames(wasm).indexOf(row);
-      if (row_idx == -1) {
-        postMessage({
-          type: "geneExpression",
-          resp: {
-            gene: row
-          },
-          msg: "Fail: GET_GENE_EXPRESSION"
-        });
-      } else {
-        var vec = scran_normalization.fetchExpression(wasm, row_idx);
-        postMessage({
-          type: "setGeneExpression",
-          resp: {
-            gene: row,
-            expr: vec
-          },
-          msg: "Success: GET_GENE_EXPRESSION done"
-        }, [vec.buffer]);
-      }
+      let row_idx = payload.payload.gene;
+      var vec = scran_normalization.fetchExpression(wasm, row_idx);
+      postMessage({
+        type: "setGeneExpression",
+        resp: {
+          gene: row_idx,
+          expr: vec
+        },
+        msg: "Success: GET_GENE_EXPRESSION done"
+      }, [vec.buffer]);
     });
   } else if (payload.type == "computeCustomMarkers") {
     loaded.then(wasm => {

--- a/src/App.js
+++ b/src/App.js
@@ -31,7 +31,7 @@ function App() {
   };
 
   const { setWasmInitialized, setTsneData, setRedDims, redDims,
-    setInitDims, setQcDims, defaultRedDims, setDefaultRedDims,
+    setGenesInfo, setInitDims, setQcDims, defaultRedDims, setDefaultRedDims,
     setQcData, qcData, setClusterData, setFSelectionData,
     setUmapData, setPcaVarExp, logs, setLogs,
     selectedCluster, clusterRank,
@@ -125,6 +125,7 @@ function App() {
       setWasmInitialized(true);
     } else if (payload.type === "inputs_DATA") {
       setInitDims(`${payload.resp.dimensions.num_genes} genes, ${payload.resp.dimensions.num_cells} cells`);
+      setGenesInfo(payload.resp.gene_names); 
     } else if (payload.type === "quality_control_metrics_DATA") {
       const { resp } = payload;
       setQcData(resp);
@@ -173,25 +174,30 @@ function App() {
     } else if (payload.type === "setMarkersForCluster"
       || payload.type === "setMarkersForCustomSelection") {
       const { resp } = payload;
-      let records = {};
+      let records = [];
       resp.means.forEach((x, i) => {
-        records[resp?.genes?.[i]] = {
-          "gene": resp?.genes?.[i],
+        records.push({
+          "index": i,
+          "row": resp?.ordering?.[i],
           "mean": x,
           "delta": resp?.delta_detected?.[i],
           "lfc": resp?.lfc?.[i],
           "detected": resp?.detected?.[i],
           "expanded": false,
           "expr": null,
-        }
+        });
       });
       setSelectedClusterSummary(records);
     } else if (payload.type === "setGeneExpression") {
       const { resp } = payload;
-
-      let gtmp = { ...selectedClusterSummary };
-      gtmp[resp.gene].expr = Object.values(resp.expr);
-      setSelectedClusterSummary(gtmp);
+      let tmp = [...selectedClusterSummary];
+      for (var i = 0; i < tmp.length; i++) {
+        if (resp.gene === tmp[i].row) {
+          tmp[i].expr = Object.values(resp.expr);
+          break;
+        }
+      }
+      setSelectedClusterSummary(tmp);
     }
   }
 

--- a/src/components/Markers/index.js
+++ b/src/components/Markers/index.js
@@ -18,7 +18,8 @@ import './markers.css';
 
 const MarkerPlot = () => {
 
-    const { clusterData, selectedClusterSummary, setSelectedClusterSummary,
+    const { 
+        genesInfo, clusterData, selectedClusterSummary, setSelectedClusterSummary,
         selectedCluster, setSelectedCluster, setClusterRank,
         setReqGene, clusterColors, gene, setGene,
         customSelection } = useContext(AppContext);
@@ -60,7 +61,7 @@ const MarkerPlot = () => {
     useEffect(() => {
         if (!selectedClusterSummary) return selectedClusterSummary;
 
-        let trecs = Object.values(selectedClusterSummary);
+        let trecs = selectedClusterSummary;
 
         if (trecs.length === 0) return trecs;
 
@@ -117,7 +118,7 @@ const MarkerPlot = () => {
 
         if (!searchInput || searchInput === "") return sortedRows;
 
-        sortedRows = sortedRows.filter((x) => x["gene"].toLowerCase().indexOf(searchInput.toLowerCase()) !== -1);
+        sortedRows = sortedRows.filter((x) => genesInfo[x.row].toLowerCase().indexOf(searchInput.toLowerCase()) !== -1);
         return sortedRows;
     }, [prosRecords, searchInput, markerFilter]);
 
@@ -252,7 +253,7 @@ const MarkerPlot = () => {
                                 return (
                                     <div>
                                         <div className='row-container'>
-                                            <span>{row.gene}</span>
+                                            <span>{genesInfo[row.row]}</span>
                                             {
                                                 <Popover2
                                                     popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
@@ -270,7 +271,7 @@ const MarkerPlot = () => {
                                                             <table>
                                                                 <tr>
                                                                     <td></td>
-                                                                    <th scope="col">{row.gene}</th>
+                                                                    <th scope="col">{genesInfo[row.row]}</th>
                                                                     <th scope="col">This cluster</th>
                                                                 </tr>
                                                                 <tr>
@@ -316,7 +317,7 @@ const MarkerPlot = () => {
                                                             <table>
                                                                 <tr>
                                                                     <td></td>
-                                                                    <th scope="col">{row.gene}</th>
+                                                                    <th scope="col">{genesInfo[row.row]}</th>
                                                                     <th scope="col">This cluster</th>
                                                                 </tr>
                                                                 <tr>
@@ -361,7 +362,7 @@ const MarkerPlot = () => {
                                                             <table>
                                                                 <tr>
                                                                     <td></td>
-                                                                    <th scope="col">{row.gene}</th>
+                                                                    <th scope="col">{genesInfo[row.row]}</th>
                                                                     <th scope="col">This cluster</th>
                                                                 </tr>
                                                                 <tr>
@@ -395,12 +396,11 @@ const MarkerPlot = () => {
                                                 <Button icon={rowexp ? 'minus' : 'plus'} small={true} fill={false}
                                                     className='row-action'
                                                     onClick={() => {
-                                                        let tmp = { ...selectedClusterSummary };
-                                                        tmp[row.gene].expanded = !tmp[row.gene].expanded;
+                                                        let tmp = [...selectedClusterSummary];
+                                                        tmp[row.index].expanded = !tmp[row.index].expanded;
                                                         setSelectedClusterSummary(tmp);
-
                                                         if (!rowExpr) {
-                                                            setReqGene(row.gene);
+                                                            setReqGene(row.row);
                                                         }
                                                     }}
                                                 >
@@ -408,18 +408,18 @@ const MarkerPlot = () => {
                                                 <Button small={true} fill={false}
                                                     className='row-action'
                                                     onClick={() => {
-                                                        if (row.gene === gene) {
+                                                        if (row.index === gene) {
                                                             setGene(null);
                                                         } else {
-                                                            setGene(row.gene);
+                                                            setGene(row.index);
                                                             if (!rowExpr) {
-                                                                setReqGene(row.gene);
+                                                                setReqGene(row.row);
                                                             }
                                                         }
                                                     }}
                                                 >
                                                     <Icon icon={'tint'}
-                                                        color={row.gene === gene ? 
+                                                        color={row.index === gene ? 
                                                             String(selectedCluster).startsWith("cs") ? clusterColors[Math.max(...clusterData?.clusters) + parseInt(selectedCluster.replace("cs", ""))] : ''
                                                             : ''}
                                                     ></Icon>

--- a/src/components/Plots/ScatterPlot.js
+++ b/src/components/Plots/ScatterPlot.js
@@ -43,8 +43,7 @@ const DimPlot = () => {
 
     // if either gene or expression changes, compute gradients and min/max
     useEffect(() => {
-
-        if (!gene || gene == "") {
+        if (gene === null) {
             setShowGradient(false);
             setGradient(null);
         }
@@ -153,7 +152,7 @@ const DimPlot = () => {
                         }
                     }
 
-                    if (gene && Array.isArray(selectedClusterSummary?.[gene]?.expr)) {
+                    if (gene !== null && Array.isArray(selectedClusterSummary?.[gene]?.expr)) {
 
                         return "#" + gradient.colorAt(selectedClusterSummary?.[gene]?.expr?.[i]);
                         // if we want per cell gradient 

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -55,6 +55,9 @@ const AppContextProvider = ({ children }) => {
   const [qcDims, setQcDims] = useState(null);
   const [fSelDims, setFSelDims] = useState(null);
 
+  // Gene details 
+  const [genesInfo, setGenesInfo] = useState(null);
+
   // QC Data
   const [qcData, setQcData] = useState(null);
   const [qcThreshold, setQcThreshold] = useState(null);
@@ -75,7 +78,7 @@ const AppContextProvider = ({ children }) => {
   // which cluster is selected
   const [selectedCluster, setSelectedCluster] = useState(null);
   // cohen, mean scores per gene
-  const [selectedClusterSummary, setSelectedClusterSummary] = useState({});
+  const [selectedClusterSummary, setSelectedClusterSummary] = useState([]);
   // set cluster colors
   const [clusterColors, setClusterColors] = useState(null);
   // set Cluster rank-type
@@ -133,6 +136,7 @@ const AppContextProvider = ({ children }) => {
         pcaVarExp, setPcaVarExp,
         tsneData, setTsneData,
         umapData, setUmapData,
+        genesInfo, setGenesInfo,
         initDims, setInitDims,
         qcDims, setQcDims,
         qcData, setQcData,


### PR DESCRIPTION
Handles the second point in #27.

The main change is that the main thread primarily operates with the matrix row indexes (`.row`). This contains the index to the row in the count/normalized/filtered matrix. (Doesn't matter which, as the rows are the same for all of them.) You don't have to worry about the permutations - that's strictly a worker-side problem.

Turned `selectedClusterSummary` into an array, to avoid issues with ordering when trying to store numeric keys in a map. As a result, each entry also has an `index` entry that refers to the index of itself in the full ordered array. This is needed in case filtering is done and you need some way to refer back to the original array. Don't confuse `.index` with `.row`; the former refers to the  _sorted array index_ while the latter refers to the _matrix row index_. 

`reqGene` and `gene` need to be renamed to something a bit more explicit. Currently we store `.row` in `reqGene` (i.e., the row of the matrix on the worker side), while we store `.index` in `gene` (i.e., the index in the `selectedClusterSummary` array on the main thread's side).

Also had to put in a few minor fixes here and there to account for the fact that a gene of zero evaluates to false, so the first gene's expression wasn't being plotted before I figured it out.