### PR TITLE
Ensure consistent coloring by gene when ordering changes.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,8 @@ function App() {
 
   // show loading screen ?
   const [loading, setLoading] = useState(true);
+  // use local state for tsne/umap animation
+  const [animateData, setAnimateData] = useState(null);
   // props for dialogs
   const loadingProps = {
     autoFocus: true,
@@ -168,44 +170,37 @@ function App() {
 
       // show markers for the first cluster
       setSelectedCluster(0);
-    } else if (payload.type === "tsne_DATA" || payload.type === "tsne_iter") {
+    } else if (payload.type === "tsne_DATA") {
       const { resp } = payload;
       setTsneData(resp);
-      setShowAnimation(true);
 
-      // assuming the last response is _data
-      if (payload.type === "tsne_DATA") {
-
-        let tmp = [...redDims];
-        tmp.push("TSNE");
-        // once t-SNE is available, set this as the default display
-        if (!defaultRedDims) {
-          setDefaultRedDims("TSNE");
-        }
-
-        setRedDims(tmp);
-        // also don't show the pong game anymore
-        setShowGame(false);
-
-        setShowAnimation(false);
-        setTriggerAnimation(false);
+      let tmp = [...redDims];
+      tmp.push("TSNE");
+      // once t-SNE is available, set this as the default display
+      if (!defaultRedDims) {
+        setDefaultRedDims("TSNE");
       }
-    } else if (payload.type === "umap_DATA" || payload.type === "umap_iter") {
+
+      setRedDims(tmp);
+      // also don't show the pong game anymore
+      setShowGame(false);
+      setShowAnimation(false);
+      setTriggerAnimation(false);
+
+    } else if (payload.type === "tsne_iter" || payload.type === "umap_iter") {
+      const { resp } = payload;
+      setAnimateData(resp);
+    } else if (payload.type === "umap_DATA") {
       const { resp } = payload;
       setUmapData(resp);
-      setShowAnimation(true);
 
-      // assuming the last response is _data
-      if (payload.type === "umap_DATA") {
+      // enable UMAP selection
+      let tmp = [...redDims];
+      tmp.push("UMAP");
+      setRedDims(tmp);
 
-        // enable UMAP selection
-        let tmp = [...redDims];
-        tmp.push("UMAP");
-        setRedDims(tmp);
-
-        setShowAnimation(false);
-        setTriggerAnimation(false);
-      }
+      setShowAnimation(false);
+      setTriggerAnimation(false);
     } else if (payload.type === "markerGene_DATA") {
     } else if (payload.type === "setMarkersForCluster"
       || payload.type === "setMarkersForCustomSelection") {
@@ -262,7 +257,7 @@ function App() {
         <div className="plot">
           {
             defaultRedDims ?
-              <DimPlot /> :
+              <DimPlot animateData={animateData}/> :
               showGame ?
                 <div style={{
                   height: '100%',

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,7 @@ function App() {
     setUmapData, setPcaVarExp, logs, setLogs,
     selectedCluster, clusterRank,
     selectedClusterSummary, setSelectedClusterSummary,
+    selectedClusterIndex, setSelectedClusterIndex,
     reqGene, customSelection, clusterData,
     delCustomSelection, setDelCustomSelection,
     setSelectedCluster, setShowGame, showGame, datasetName, setExportState,
@@ -210,10 +211,11 @@ function App() {
       || payload.type === "setMarkersForCustomSelection") {
       const { resp } = payload;
       let records = [];
+      let index = Array(resp.ordering.length);
       resp.means.forEach((x, i) => {
+        index[resp.ordering[i]] = i;
         records.push({
-          "index": i,
-          "row": resp?.ordering?.[i],
+          "gene": resp?.ordering?.[i],
           "mean": x,
           "delta": resp?.delta_detected?.[i],
           "lfc": resp?.lfc?.[i],
@@ -222,16 +224,12 @@ function App() {
           "expr": null,
         });
       });
+      setSelectedClusterIndex(index);
       setSelectedClusterSummary(records);
     } else if (payload.type === "setGeneExpression") {
       const { resp } = payload;
       let tmp = [...selectedClusterSummary];
-      for (var i = 0; i < tmp.length; i++) {
-        if (resp.gene === tmp[i].row) {
-          tmp[i].expr = Object.values(resp.expr);
-          break;
-        }
-      }
+      tmp[selectedClusterIndex[resp.gene]].expr = Object.values(resp.expr);
       setSelectedClusterSummary(tmp);
     } else if (payload.type === "exportState") {
       const { resp } = payload;

--- a/src/components/Markers/index.js
+++ b/src/components/Markers/index.js
@@ -123,7 +123,7 @@ const MarkerPlot = () => {
 
         if (!searchInput || searchInput === "") return sortedRows;
 
-        sortedRows = sortedRows.filter((x) => genesInfo[geneColSel][x.row].toLowerCase().indexOf(searchInput.toLowerCase()) !== -1);
+        sortedRows = sortedRows.filter((x) => genesInfo[geneColSel][x.gene].toLowerCase().indexOf(searchInput.toLowerCase()) !== -1);
         return sortedRows;
     }, [prosRecords, searchInput, markerFilter]);
 
@@ -268,11 +268,11 @@ const MarkerPlot = () => {
                                     <div>
                                         <div className='row-container'>
                                             <span style={{
-                                                color: row.index === gene ?
+                                                color: row.gene === gene ?
                                                     String(selectedCluster).startsWith("cs") ? clusterColors[Math.max(...clusterData?.clusters) + parseInt(selectedCluster.replace("cs", ""))] : clusterColors[selectedCluster]
                                                     : 'black'
                                             }}
-                                                className={row.index === gene ? 'marker-gene-title-selected' : 'marker-gene-title'}>{genesInfo[geneColSel][row.row]}</span>
+                                                className={row.gene === gene ? 'marker-gene-title-selected' : 'marker-gene-title'}>{genesInfo[geneColSel][row.gene]}</span>
                                             {
                                                 <Popover2
                                                     popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
@@ -290,7 +290,7 @@ const MarkerPlot = () => {
                                                             <table>
                                                                 <tr>
                                                                     <td></td>
-                                                                    <th scope="col">{genesInfo[geneColSel][row.row]}</th>
+                                                                    <th scope="col">{genesInfo[geneColSel][row.gene]}</th>
                                                                     <th scope="col">This cluster</th>
                                                                 </tr>
                                                                 <tr>
@@ -336,7 +336,7 @@ const MarkerPlot = () => {
                                                             <table>
                                                                 <tr>
                                                                     <td></td>
-                                                                    <th scope="col">{genesInfo[geneColSel][row.row]}</th>
+                                                                    <th scope="col">{genesInfo[geneColSel][row.gene]}</th>
                                                                     <th scope="col">This cluster</th>
                                                                 </tr>
                                                                 <tr>
@@ -381,7 +381,7 @@ const MarkerPlot = () => {
                                                             <table>
                                                                 <tr>
                                                                     <td></td>
-                                                                    <th scope="col">{genesInfo[geneColSel][row.row]}</th>
+                                                                    <th scope="col">{genesInfo[geneColSel][row.gene]}</th>
                                                                     <th scope="col">This cluster</th>
                                                                 </tr>
                                                                 <tr>
@@ -416,10 +416,10 @@ const MarkerPlot = () => {
                                                     className='row-action'
                                                     onClick={() => {
                                                         let tmp = [...selectedClusterSummary];
-                                                        tmp[row.index].expanded = !tmp[row.index].expanded;
+                                                        tmp[index].expanded = !tmp[index].expanded;
                                                         setSelectedClusterSummary(tmp);
                                                         if (!rowExpr) {
-                                                            setReqGene(row.row);
+                                                            setReqGene(row.gene);
                                                         }
                                                     }}
                                                 >
@@ -427,18 +427,18 @@ const MarkerPlot = () => {
                                                 <Button small={true} fill={false}
                                                     className='row-action'
                                                     onClick={() => {
-                                                        if (row.index === gene) {
+                                                        if (row.gene === gene) {
                                                             setGene(null);
                                                         } else {
-                                                            setGene(row.index);
+                                                            setGene(row.gene);
                                                             if (!rowExpr) {
-                                                                setReqGene(row.row);
+                                                                setReqGene(row.gene);
                                                             }
                                                         }
                                                     }}
                                                 >
                                                     <Icon icon={'tint'}
-                                                        color={row.index === gene ?
+                                                        color={row.gene === gene ?
                                                             String(selectedCluster).startsWith("cs") ? clusterColors[Math.max(...clusterData?.clusters) + parseInt(selectedCluster.replace("cs", ""))] : clusterColors[selectedCluster]
                                                             : ''}
                                                     ></Icon>

--- a/src/components/Plots/ScatterPlot.js
+++ b/src/components/Plots/ScatterPlot.js
@@ -9,7 +9,7 @@ import {
 import { Tooltip2 } from "@blueprintjs/popover2";
 
 import { AppContext } from '../../context/AppContext';
-import {getMinMax} from './utils';
+import { getMinMax } from './utils';
 
 import Rainbow from './rainbowvis';
 import { randomColor } from 'randomcolor';
@@ -17,7 +17,7 @@ import { randomColor } from 'randomcolor';
 import "./ScatterPlot.css";
 import { AppToaster } from "../Spinners/AppToaster";
 
-const DimPlot = () => {
+const DimPlot = (props) => {
     const container = useRef();
 
     // ref to the plot object
@@ -39,7 +39,7 @@ const DimPlot = () => {
         tsneData, umapData, clusterColors, setClusterColors,
         gene, setGene, selectedClusterIndex, selectedClusterSummary,
         customSelection, setCustomSelection,
-        setDelCustomSelection,
+        setDelCustomSelection, setShowAnimation,
         showAnimation, setTriggerAnimation,
         savedPlot, setSavedPlot, selectedCluster,
         genesInfo, geneColSel } = useContext(AppContext);
@@ -73,7 +73,7 @@ const DimPlot = () => {
                 setExprMinMax([0, val]);
             } else {
                 setShowGradient(false);
-                AppToaster.show({icon:"warning-sign", intent: "warning", message: `${genesInfo[geneColSel][gene]} is not expressed in any cell (mean = 0)`})
+                AppToaster.show({ icon: "warning-sign", intent: "warning", message: `${genesInfo[geneColSel][gene]} is not expressed in any cell (mean = 0)` })
             }
             setGradient(tmpgradient);
         }
@@ -130,10 +130,15 @@ const DimPlot = () => {
             }
 
             let data = null;
-            if (defaultRedDims === "TSNE") {
-                data = tsneData;
-            } else if (defaultRedDims === "UMAP") {
-                data = umapData;
+
+            if (showAnimation) {
+                data = props?.animateData;
+            } else {
+                if (defaultRedDims === "TSNE") {
+                    data = tsneData;
+                } else if (defaultRedDims === "UMAP") {
+                    data = umapData;
+                }
             }
 
             // if dimensions are available
@@ -198,7 +203,7 @@ const DimPlot = () => {
                             // });
 
                             // return "#" + colorGradients[cluster_mappings[i]].colorAt(selectedClusterSummary?.[gene]?.expr?.[i])
-                        } 
+                        }
                     }
 
                     if (clusHighlight != null && String(clusHighlight).startsWith("cs")) {
@@ -210,9 +215,9 @@ const DimPlot = () => {
                 });
             }
         }
-    }, [tsneData, umapData, defaultRedDims, gradient, clusHighlight]);
+    }, [tsneData, umapData, props?.animateData, defaultRedDims, gradient, clusHighlight]);
 
-    const setInteraction = (x) => {        
+    const setInteraction = (x) => {
         if (x === "SELECT") {
             scatterplot.setSelectMode();
             setPlotMode("SELECT");
@@ -252,7 +257,7 @@ const DimPlot = () => {
             // preserve drawing buffers is false, so render and capture state right away
             scatterplot.renderScatterPlot();
             const iData = scatterplot.scatterPlot.renderer.domElement.toDataURL();
-            
+
             let tmp = [...savedPlot];
 
             tmp.push({
@@ -310,7 +315,10 @@ const DimPlot = () => {
                     }}>
                     <Tooltip2 content="Interactively visualize embeddings">
                         <Button icon="play"
-                            onClick={() => setTriggerAnimation(true)}>Animate</Button>
+                            onClick={() => {
+                                setShowAnimation(true); 
+                                setTriggerAnimation(true)
+                            }}>Animate</Button>
                     </Tooltip2>
                     <Tooltip2 content="Save this embedding">
                         <Button icon="inheritance"
@@ -453,11 +461,11 @@ const DimPlot = () => {
                         <div className='right-sidebar-slider'>
                             <Divider />
                             <Callout>
-                                <span>Gradient for <Tag 
-                                minimal={true}
-                                intent='primary' onRemove={() => {
-                                    setGene(null);
-                                }}>{genesInfo[geneColSel][gene]}</Tag>&nbsp;
+                                <span>Gradient for <Tag
+                                    minimal={true}
+                                    intent='primary' onRemove={() => {
+                                        setGene(null);
+                                    }}>{genesInfo[geneColSel][gene]}</Tag>&nbsp;
                                     <Tooltip2 content="Use the slider to adjust the color gradient of the plot. Useful when data is skewed
                                 by either a few lowly or highly expressed cells" openOnTargetFocus={false}>
                                         <Icon icon="help"></Icon>

--- a/src/components/Plots/ScatterPlot.js
+++ b/src/components/Plots/ScatterPlot.js
@@ -37,7 +37,7 @@ const DimPlot = () => {
 
     const { redDims, defaultRedDims, setDefaultRedDims, clusterData,
         tsneData, umapData, clusterColors, setClusterColors,
-        gene, setGene, selectedClusterSummary,
+        gene, setGene, selectedClusterIndex, selectedClusterSummary,
         customSelection, setCustomSelection,
         setDelCustomSelection,
         showAnimation, setTriggerAnimation,
@@ -58,8 +58,11 @@ const DimPlot = () => {
             setGradient(null);
         }
 
-        if (selectedClusterSummary?.[gene]?.expr) {
-            let exprMinMax = getMinMax(selectedClusterSummary?.[gene]?.expr);
+        let index = selectedClusterIndex?.[gene];
+        let expr = selectedClusterSummary?.[index]?.expr;
+
+        if (expr) {
+            let exprMinMax = getMinMax(expr);
             let val = exprMinMax[1] === 0 ? 0.01 : exprMinMax[1];
             let tmpgradient = new Rainbow();
             tmpgradient.setSpectrum('#F5F8FA', "#2965CC");
@@ -70,11 +73,11 @@ const DimPlot = () => {
                 setExprMinMax([0, val]);
             } else {
                 setShowGradient(false);
-                AppToaster.show({icon:"warning-sign", intent: "warning", message: `${genesInfo[geneColSel][selectedClusterSummary?.[gene]?.row]} is not expressed in any cell (mean = 0)`})
+                AppToaster.show({icon:"warning-sign", intent: "warning", message: `${genesInfo[geneColSel][gene]} is not expressed in any cell (mean = 0)`})
             }
             setGradient(tmpgradient);
         }
-    }, [selectedClusterSummary?.[gene]?.expr], gene);
+    }, [selectedClusterIndex?.[gene], selectedClusterSummary?.[selectedClusterIndex?.[gene]]?.expr], gene);
 
     // hook to also react when user changes the slider
     useEffect(() => {
@@ -179,19 +182,23 @@ const DimPlot = () => {
                         }
                     }
 
-                    if (gene !== null && Array.isArray(selectedClusterSummary?.[gene]?.expr)) {
+                    if (gene !== null) {
+                        let index = selectedClusterIndex?.[gene];
+                        let expr = selectedClusterSummary?.[index]?.expr;
 
-                        return "#" + gradient.colorAt(selectedClusterSummary?.[gene]?.expr?.[i]);
-                        // if we want per cell gradient 
-                        // let colorGradients = cluster_colors.map(x => {
-                        //     var gradient = new Rainbow();
-                        //     gradient.setSpectrum('#D3D3D3', x);
-                        //     let val = exprMinMax[1] === 0 ? 0.01 : exprMinMax[1];
-                        //     gradient.setNumberRange(0, val);
-                        //     return gradient;
-                        // });
+                        if (Array.isArray(expr)) {
+                            return "#" + gradient.colorAt(expr?.[i]);
+                            // if we want per cell gradient 
+                            // let colorGradients = cluster_colors.map(x => {
+                            //     var gradient = new Rainbow();
+                            //     gradient.setSpectrum('#D3D3D3', x);
+                            //     let val = exprMinMax[1] === 0 ? 0.01 : exprMinMax[1];
+                            //     gradient.setNumberRange(0, val);
+                            //     return gradient;
+                            // });
 
-                        // return "#" + colorGradients[cluster_mappings[i]].colorAt(selectedClusterSummary?.[gene]?.expr?.[i])
+                            // return "#" + colorGradients[cluster_mappings[i]].colorAt(selectedClusterSummary?.[gene]?.expr?.[i])
+                        } 
                     }
 
                     if (clusHighlight != null && String(clusHighlight).startsWith("cs")) {
@@ -450,7 +457,7 @@ const DimPlot = () => {
                                 minimal={true}
                                 intent='primary' onRemove={() => {
                                     setGene(null);
-                                }}>{genesInfo[geneColSel][selectedClusterSummary?.[gene]?.row]}</Tag>&nbsp;
+                                }}>{genesInfo[geneColSel][gene]}</Tag>&nbsp;
                                     <Tooltip2 content="Use the slider to adjust the color gradient of the plot. Useful when data is skewed
                                 by either a few lowly or highly expressed cells" openOnTargetFocus={false}>
                                         <Icon icon="help"></Icon>

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -106,6 +106,8 @@ const AppContextProvider = ({ children }) => {
   const [selectedCluster, setSelectedCluster] = useState(null);
   // cohen, mean scores per gene
   const [selectedClusterSummary, setSelectedClusterSummary] = useState([]);
+  // ordering of genes for the selected cluster
+  const [selectedClusterIndex, setSelectedClusterIndex] = useState([]);
   // set cluster colors
   const [clusterColors, setClusterColors] = useState(null);
   // set Cluster rank-type
@@ -257,6 +259,7 @@ const AppContextProvider = ({ children }) => {
         logs, setLogs,
         selectedCluster, setSelectedCluster,
         selectedClusterSummary, setSelectedClusterSummary,
+        selectedClusterIndex, setSelectedClusterIndex,
         clusterRank, setClusterRank,
         gene, setGene,
         clusterColors, setClusterColors,


### PR DESCRIPTION
Simplifies `gene` and `reqGene` so that they now contain the same value - the latter triggers a fresh request for expression values, the former triggers a recolor of the scatter plot.

Not sure about some of the React-ish parts:

- Did I do the right thing in the second argument of `useEffect` in `ScatterPlot.js`?
- In various parts, I put `let tmp = [...selectedClusterSummary];` before assigning `setSelectedClusterSummary(tmp);`. Can't we just modify `selectedClusterSummary` in place and then call `setSelectedClusterSummary(selectedClusterSummary)`?