### PR TITLE
Switch to PCA partitioning for k-means initialization.

### DIFF
--- a/src/workers/_kmeans_cluster.js
+++ b/src/workers/_kmeans_cluster.js
@@ -35,7 +35,7 @@ export function compute(args) {
     } else {
         utils.freeCache(cache.raw);
         var pcs = pca.fetchPCs();
-        cache.raw = scran.clusterKmeans(pcs.pcs, args.k, { numberOfDims: pcs.num_pcs, numberOfCells: pcs.num_obs });
+        cache.raw = scran.clusterKmeans(pcs.pcs, args.k, { numberOfDims: pcs.num_pcs, numberOfCells: pcs.num_obs, initMethod: "pca-part" });
         parameters = args;
         changed = true;
         utils.freeReloaded(cache);


### PR DESCRIPTION
Depends on jkanche/scran.js#36.

I'm thinking we should also add a UI option to set the seed, given how sensitive k-means is to the initialization process. (Depending on how that goes, we might consider adding a similar option to t-SNE and UMAP, so people can play around with the seed and see how their results change.)