### PR TITLE
Added general-purpose handler for long-term download caching.

### DIFF
--- a/src/workers/DownloadsDBHandler.js
+++ b/src/workers/DownloadsDBHandler.js
@@ -1,0 +1,122 @@
+var DownloadsDB;
+var init = null;
+
+export function initialize() {
+    init = new Promise(resolve => {
+        // initialize database on worker creation
+        DownloadsDB = indexedDB.open("DownloadsDB", 3);
+
+        DownloadsDB.onupgradeneeded = (e) => {
+            var DownloadsDBClient = e.target.result;
+
+            // Currently purging all existing stores when the version is updated.
+            // At some point we may add a more sophisticated upgrade mechanism.
+            try {
+                DownloadsDBClient.deleteObjectStore("downloads");
+            } catch (e) {}
+
+            DownloadsDBClient.createObjectStore("downloads", { keyPath: 'url' });
+        };
+
+        DownloadsDB.onsuccess = () => {
+            resolve(null);
+        };
+
+        DownloadsDB.onerror = () => {
+            resolve(null);
+        };
+    });
+
+    return init;
+}
+
+export async function list() {
+    await init;
+    let trans = DownloadsDB.result.transaction(["downloads"], "readonly");
+    let download_store = trans.objectStore("downloads");
+    return download_store.getAllKeys();
+}
+
+export async function get(url, init = null, force = false) {
+    await init;
+
+    if (!force) {
+        let trans = DownloadsDB.result.transaction(["downloads"], "readonly");
+        let download_store = trans.objectStore("downloads");
+        var data_check = new Promise(resolve => {
+            console.log(url);
+            var already = download_store.get(url);
+            already.onsuccess = function (event) {
+                if (already.result !== undefined) {
+                    resolve(already.result.payload);
+                } else {
+                    resolve(null);
+                }
+            };
+            already.onerror = function (event) {
+                resolve(null);
+            };
+        });
+
+        var found = await data_check;
+        if (found !== null) {
+            return found;
+        }
+    }
+
+    var req;
+    if (init == null) {
+        req = fetch(url);
+    } else {
+        req = fetch(url, init);
+    }
+
+    var res = await req;
+    var buffer = await res.arrayBuffer();
+
+    // Technically, this isn't quite right, because we need to close the read
+    // transaction before opening the write transaction; multiple queries to
+    // the same URL from different workers could cause multiple downloads if
+    // they each miss each other's read check. But oh well; the auto-commit
+    // of IDB transactions means that it's hard to do any better. (Specifically,
+    // we can't do an async fetch while the transaction is still open, because
+    // it just closes before the fetch is done.)
+    let trans = DownloadsDB.result.transaction(["downloads"], "readwrite");
+    let download_store = trans.objectStore("downloads");
+    var data_saving = new Promise(resolve => {
+        console.log(url);
+        var putrequest = download_store.put({ "url": url, "payload": buffer });
+        putrequest.onsuccess = function (event) {
+            resolve(true);
+        };
+        putrequest.onerror = function (event) {
+            resolve(false);
+        };
+    });
+
+    let success = await data_saving;
+    console.log(success);
+    if (!success) {
+        throw "failed to download resources for '" + url + "'";
+    }
+
+    return buffer;
+}
+
+export async function remove(url) {
+    await init;
+    let trans = DownloadsDB.result.transaction(["downloads"], "readwrite")
+    let download_store = trans.objectStore("downloads");
+
+    var removal = new Promise(resolve => {
+        let request = download_store.delete(url);
+        request.onsuccess = function (event) {
+            resolve(true);
+        };
+        request.onerror = function (event) {
+            resolve(false);
+        };
+    });
+
+    return await removal;
+}


### PR DESCRIPTION
```html
<html>
<script type="module">
import * as thing from "./DownloadsDBHandler.js";
await thing.initialize();
await thing.remove("https://anime-gifs.aaron-lun.workers.dev/random/gif");
let stuff = await thing.get("https://anime-gifs.aaron-lun.workers.dev/random/gif");
console.log(stuff);
let stuff2 = await thing.get("https://anime-gifs.aaron-lun.workers.dev/random/gif");
console.log(stuff2); # same size, retrieved from cache.
</script>
</html>
```

The immediate pickle is that the SinglePP references are held as GitHub Artifacts, and those don't have CORS enabled. We'll have to move them to a GH pages location to be able to download them properly.

A more general concern is the fact that IndexedDB has this strange auto-committing behavior whereby the transaction closes on the last callback. This seems to imply that we cannot do any asynchronous operations after the first request, which means that I can't, e.g., read the database, download the file and save it in a single transaction. Right now I'm using two transactions, which has implications for multiple queries - for example, if you remove the `await`s above, you'll get two different buffer sizes. 

(The second point also makes me think about some of our single-transaction-multi-request code in `KanaDBHandler.js`. I think it is correct, but its correctness is not obvious, and relies on the timings of operations from a single-threaded process.)