### PR TITLE
Adding block-awareness to all relevant steps.

### DIFF
--- a/src/components/Analysis/index.js
+++ b/src/components/Analysis/index.js
@@ -533,7 +533,7 @@ const AnalysisDialog = ({
                                 onValueChange={(nval, val) => { setTmpInputParams({ ...tmpInputParams, "pca": { ...tmpInputParams["pca"], "pca-npc": nval } }) }} />
                         </Label>
                         {
-                            tmpInputFiles.length > 1 && <Label className="row-input">
+                            (tmpInputFiles.length > 1 || (tmpInputFiles.length == 1 && tmpInputFiles[0]?.batch && tmpInputFiles[0]?.batch.toLowerCase() != "none")) && <Label className="row-input">
                                 <Text className="text-100">
                                     <span className={showStepHelper == 4 ? 'row-tooltip row-tooltip-highlight' : 'row-tooltip'}
                                         onMouseEnter={() => setShowStepHelper(4)}>
@@ -544,9 +544,9 @@ const AnalysisDialog = ({
                                     onChange={(e) => { setTmpInputParams({ ...tmpInputParams, "pca": { ...tmpInputParams["pca"], "pca-correction": e.target.value } }) }}
                                     defaultValue={tmpInputParams["pca"]["pca-correction"]}
                                 >
-                                    <option value="no_correction">No Correction</option>
-                                    <option value="linear_regression">Linear Regression</option>
-                                    <option value="mnn_correction">MNN correction</option>
+                                    <option value="none">No Correction</option>
+                                    <option value="regress">Linear Regression</option>
+                                    <option value="mnn">MNN correction</option>
                                 </HTMLSelect>
                             </Label>
                         }

--- a/src/workers/_inputs.js
+++ b/src/workers/_inputs.js
@@ -314,3 +314,8 @@ export function fetchAnnotations(col) {
         "factor": uTypedAray
     }
 }
+
+export fetchBlock() {
+    /* TODO: actually return a blocking vector as a Int32WasmArray. */
+    return null;
+}

--- a/src/workers/_inputs.js
+++ b/src/workers/_inputs.js
@@ -25,7 +25,7 @@ function merge_datasets(odatasets) {
         cache = datasets[keys[0]];
 
         let batchfield = parameters[keys[0]].batch;
-        if (batchfield && batchfield != "none") {
+        if (batchfield && batchfield.toLowerCase() != "none") {
 
             let anno_batch = cache.annotations[batchfield]
             if (anno_batch && anno_batch.length == cache.matrix.numberOfColumns()) {

--- a/src/workers/_model_gene_var.js
+++ b/src/workers/_model_gene_var.js
@@ -1,6 +1,7 @@
 import * as scran from "scran.js"; 
 import * as utils from "./_utils.js";
 import * as normalization from "./_normalization.js";
+import * as qc from "_quality_control.js";
   
 var cache = {};
 var parameters = {};
@@ -14,7 +15,8 @@ export function compute(span) {
         utils.freeCache(cache.results);
 
         let mat = normalization.fetchNormalizedMatrix();
-        cache.results = scran.modelGeneVar(mat, { span: span });
+        let block = qc.fetchFilteredBlock();
+        cache.results = scran.modelGeneVar(mat, { span: span, block: block });
 
         cache.sorted_residuals = cache.results.residuals().slice(); // a separate copy.
         cache.sorted_residuals.sort();

--- a/src/workers/_model_gene_var.js
+++ b/src/workers/_model_gene_var.js
@@ -1,7 +1,7 @@
 import * as scran from "scran.js"; 
 import * as utils from "./_utils.js";
 import * as normalization from "./_normalization.js";
-import * as qc from "_quality_control.js";
+import * as qc from "./_quality_control.js";
   
 var cache = {};
 var parameters = {};

--- a/src/workers/_normalization.js
+++ b/src/workers/_normalization.js
@@ -28,8 +28,10 @@ function rawCompute() {
         throw "normalization and filtering are not in sync";
     }
 
+    var block = qc.fetchFilteredBlock();
+
     utils.freeCache(cache.matrix);
-    cache.matrix = scran.logNormCounts(mat, { sizeFactors: buffer });
+    cache.matrix = scran.logNormCounts(mat, { sizeFactors: buffer, block: block });
     return;
 }
 

--- a/src/workers/_pca.js
+++ b/src/workers/_pca.js
@@ -11,10 +11,10 @@ var parameters = {};
 export var changed = false;
 
 function fetchPCsAsWasmArray() {
-    if (parameters.block_method == "none") {
-        return cache.pcs.principalComponents({ copy: "view" });
-    } else {
+    if (parameters.block_method == "mnn") {
         return cache.corrected;
+    } else {
+        return cache.pcs.principalComponents({ copy: "view" });
     }
 }
 

--- a/src/workers/_pca.js
+++ b/src/workers/_pca.js
@@ -1,6 +1,7 @@
 import * as scran from "scran.js";
 import * as utils from "./_utils.js";
 import * as normalization from "./_normalization.js";
+import * as qc from "./_quality_control.js";
 import * as variance from "./_model_gene_var.js";
 import * as wa from "wasmarrays.js";
 
@@ -59,7 +60,7 @@ export function compute(num_hvgs, num_pcs, block_method = "none") {
 
         if (block_method == "mnn") {
             let pcs =  cache.pcs.principalComponents({ copy:"view" });
-            let corrected = utils.allocateCachedWasmArray(pcs.length, "Float64Array", cache, "corrected");
+            let corrected = utils.allocateCachedArray(pcs.length, "Float64Array", cache, "corrected");
             scran.mnnCorrect(cache.pcs, block, { buffer: corrected });
         }
 
@@ -154,7 +155,7 @@ export function unserialize(handle) {
         // downstream steps don't care about the distinction.
         if (parameters.block_method != "none") {
             let pcs =  cache.pcs.principalComponents({ copy:"view" });
-            let corrected = utils.allocateCachedWasmArray(pcs.length, "Float64Array", cache, "corrected");
+            let corrected = utils.allocateCachedArray(pcs.length, "Float64Array", cache, "corrected");
             corrected.set(pcs);
         }
     }

--- a/src/workers/_quality_control.js
+++ b/src/workers/_quality_control.js
@@ -59,17 +59,19 @@ function applyFilters() {
     utils.freeCache(cache.matrix);
     cache.matrix = scran.filterCells(mat, disc);
 
+    let block = inputs.fetchBlock();
+
     cache.blocked = (block !== null);
     if (cache.blocked) {
-        let block = inputs.fetchBlock();
-        let bcache = utils.allocateCachedArray(cache.mat.numberOfColumns(), "Int32Array", cache, "block_buffer");
+        let bcache = utils.allocateCachedArray(cache.matrix.numberOfColumns(), "Int32Array", cache, "block_buffer");
 
         let bcache_arr = bcache.array();
         let block_arr = block.array();
+        let disc_arr = disc.array();
         let j = 0;
-        for (let i = 0; i < block.length; i++) {
-            if (disc[i] == 0) {
-                barr[j] = block[i];
+        for (let i = 0; i < block_arr.length; i++) {
+            if (disc_arr[i] == 0) {
+                bcache_arr[j] = block_arr[i];
                 j++;
             }
         }
@@ -342,6 +344,4 @@ export function fetchFilteredBlock() {
     } else {
         return null;
     }
-}
-
 }

--- a/src/workers/_score_markers.js
+++ b/src/workers/_score_markers.js
@@ -1,6 +1,7 @@
 import * as scran from "scran.js"; 
 import * as utils from "./_utils.js";
 import * as normalization from "./_normalization.js";
+import * as qc from "./_quality_control.js";
 import * as choice from "./_choose_clustering.js";
 import * as markers from "./_utils_markers.js";
 
@@ -15,9 +16,10 @@ export function compute() {
     if (normalization.changed || choice.changed) {
         var mat = normalization.fetchNormalizedMatrix();
         var clusters = choice.fetchClustersAsWasmArray();
+        var block = qc.fetchFilteredBlock();
         
         utils.freeCache(cache.raw);
-        cache.raw = scran.scoreMarkers(mat, clusters);
+        cache.raw = scran.scoreMarkers(mat, clusters, { block: block });
 
         // No parameters to set.
         changed = true;

--- a/src/workers/scran.worker.js
+++ b/src/workers/scran.worker.js
@@ -81,7 +81,8 @@ function runAllSteps(state) {
 
     pca.compute(
         state.params.pca["pca-hvg"], 
-        state.params.pca["pca-npc"]
+        state.params.pca["pca-npc"],
+        state.params.pca["pca-correction"]
     );
     postSuccess(pca, step_pca, "Principal components analysis completed");
 


### PR DESCRIPTION
Untested. 

This requires formulation of the batch vector in `_inputs.js`. This should be an `Int32WasmArray`, so best to use `allocateCachedArray` of length equal to the total number of columns across all samples.

I'll need another UI element at the PCA step asking for "none", "mnn" or "regress" - this should be passed in as `block_method` in the `compute()` function of `_pca.js`, at around L85 of `scran.worker.js`. (Might as well do the reverse in L222.)