### PR TITLE
Added UI elements for subsetting on column annotations.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -425,14 +425,16 @@ const App = () => {
         add_to_logs("complete", payload.type.toLowerCase().replace("_cache", ""), "finished (from cache)");
       } else if (payload.type.toLowerCase().endsWith("data")) {
         add_to_logs("complete", payload.type.toLowerCase().replace("_data", ""), "finished");
-      } else if (payload.type.toLowerCase().endsWith("error")) {
-        const { resp } = payload;
+      }
+
+      const { resp } = payload;
+      if (payload.type.toLowerCase().endsWith("error") || resp?.status === "ERROR") {
         add_to_logs("error", `${resp.reason}`, "");
 
         setScranError({
           type: payload.type,
           msg: resp.reason,
-          fatal: resp.fatal
+          fatal: resp?.fatal === undefined ? true: resp.fatal
         });
 
         return;

--- a/src/components/Analysis/index.js
+++ b/src/components/Analysis/index.js
@@ -1598,17 +1598,35 @@ const AnalysisDialog = ({
                                                         minimal={true}
                                                         onChange={(e) => {
                                                             let tmp = [...tmpInputFiles];
-                                                            tmp[0]["subset"] = { field: e.target.value };
 
-                                                            let available = new Set;
-                                                            for (const v of Object.values(preInputFilesStatus.annotations)) {
-                                                                if (v !== null && e.target.value in v) {
-                                                                    let current = v[e.target.value];
-                                                                    current.values.forEach(x => available.add(x));
+                                                            if (e.target.value == "none") {
+                                                                delete tmp[0]["subset"];
+                                                            } else {
+                                                                tmp[0]["subset"] = { field: e.target.value };
+
+                                                                let available = new Set;
+                                                                let truncated = false;
+                                                                for (const v of Object.values(preInputFilesStatus.annotations)) {
+                                                                    if (v !== null && e.target.value in v) {
+                                                                        let current = v[e.target.value];
+                                                                        current.values.forEach(x => available.add(x));
+                                                                        truncated = truncated || current.truncated;
+                                                                    }
                                                                 }
+
+                                                                let options = Array.from(available).sort();
+                                                                if (options.length >= 70) {
+                                                                    // yes, these numbers are meant to be different.
+                                                                    // it's like speeding; you have to be way over the 
+                                                                    // limit before the truncation kicks in.
+                                                                    options = options.slice(0, 50); 
+                                                                    truncated = true;
+                                                                }
+                                                                tmp[0]["subset"].options = options;
+
+                                                                tmp[0]["subset"].values = new Set;
+                                                                tmp[0]["subset"].truncated = truncated;
                                                             }
-                                                            tmp[0]["subset"].values = available;
-                                                            tmp[0]["subset"].options = Array.from(available).sort();
 
                                                             setTmpInputFiles(tmp);
                                                         }}
@@ -1637,7 +1655,6 @@ const AnalysisDialog = ({
                                                         tmpInputFiles[0].subset &&
                                                         tmpInputFiles[0].subset.field != "none" &&
                                                         <>
-                                                            <br/>
                                                             {
                                                                 tmpInputFiles[0].subset.options.map(x => 
                                                                     <Checkbox 
@@ -1656,6 +1673,9 @@ const AnalysisDialog = ({
                                                                         }}
                                                                     />
                                                                 )
+                                                            }
+                                                            {
+                                                                tmpInputFiles[0].subset.truncated && "... and more"
                                                             }
                                                         </>
                                                     }

--- a/src/components/Analysis/index.js
+++ b/src/components/Analysis/index.js
@@ -1678,7 +1678,8 @@ const AnalysisDialog = ({
                                                                         return <>
                                                                             {
                                                                                 tmpInputFiles[0].subset.options.map(x => 
-                                                                                    <Checkbox 
+                                                                                    <Checkbox
+                                                                                        key={"subset-" + x}
                                                                                         checked={tmpInputFiles[0].subset.values.has(x)} 
                                                                                         label={x}
                                                                                         inline={true}
@@ -1700,9 +1701,9 @@ const AnalysisDialog = ({
                                                                         </>
                                                                     } else {
                                                                         return <>
-                                                                            <table>
+                                                                            <table style={{display:"inline-table", verticalAlign: "top"}}>
                                                                                 <tr>
-                                                                                    <td>From</td>
+                                                                                    <td>from</td>
                                                                                     <td> 
                                                                                         <NumericInput 
                                                                                             min={isFinite(tmpInputFiles[0].subset.min) ? tmpInputFiles[0].subset.min : undefined}

--- a/src/components/Analysis/index.js
+++ b/src/components/Analysis/index.js
@@ -1084,13 +1084,28 @@ const AnalysisDialog = ({
                             <div className="row"
                             >
                                 <Label className="row-input">
-                                    <FileInput text={sinputText.mtx} onInputChange={(msg) => { ssetInputText({ ...sinputText, "mtx": msg.target.files[0].name }); ssetTmpInputFiles({ ...stmpInputFiles, "mtx": msg.target.files[0] }) }} />
+                                    <FileInput text={sinputText.mtx} onInputChange={(msg) => { 
+                                        if (msg.target.files) {
+                                            ssetInputText({ ...sinputText, "mtx": msg.target.files[0].name }); 
+                                            ssetTmpInputFiles({ ...stmpInputFiles, "mtx": msg.target.files[0] }) 
+                                        }
+                                    }} />
                                 </Label>
                                 <Label className="row-input">
-                                    <FileInput text={sinputText.genes} onInputChange={(msg) => { ssetInputText({ ...sinputText, "genes": msg.target.files[0].name }); ssetTmpInputFiles({ ...stmpInputFiles, "genes": msg.target.files[0] }) }} />
+                                    <FileInput text={sinputText.genes} onInputChange={(msg) => { 
+                                        if (msg.target.files) {
+                                            ssetInputText({ ...sinputText, "genes": msg.target.files[0].name }); 
+                                            ssetTmpInputFiles({ ...stmpInputFiles, "genes": msg.target.files[0] }) 
+                                        }
+                                    }} />
                                 </Label>
                                 <Label className="row-input">
-                                    <FileInput text={sinputText.annotations} onInputChange={(msg) => { ssetInputText({ ...sinputText, "annotations": msg.target.files[0].name }); ssetTmpInputFiles({ ...stmpInputFiles, "annotations": msg.target.files[0] }) }} />
+                                    <FileInput text={sinputText.annotations} onInputChange={(msg) => { 
+                                        if (msg.target.files) {
+                                            ssetInputText({ ...sinputText, "annotations": msg.target.files[0].name }); 
+                                            ssetTmpInputFiles({ ...stmpInputFiles, "annotations": msg.target.files[0] }) 
+                                        }
+                                    }} />
                                 </Label>
                             </div>
                         } />
@@ -1103,8 +1118,10 @@ const AnalysisDialog = ({
                                     }}
                                         text={sinputText.h5}
                                         onInputChange={(msg) => {
-                                            ssetInputText({ ...sinputText, "h5": msg.target.files[0].name });
-                                            ssetTmpInputFiles({ ...stmpInputFiles, "h5": msg.target.files[0] })
+                                            if (msg.target.files) {
+                                                ssetInputText({ ...sinputText, "h5": msg.target.files[0].name });
+                                                ssetTmpInputFiles({ ...stmpInputFiles, "h5": msg.target.files[0] })
+                                            }
                                         }} />
                                 </Label>
                             </div>
@@ -1118,8 +1135,10 @@ const AnalysisDialog = ({
                                     }}
                                         text={sinputText.h5}
                                         onInputChange={(msg) => {
-                                            ssetInputText({ ...sinputText, "h5": msg.target.files[0].name });
-                                            ssetTmpInputFiles({ ...stmpInputFiles, "h5": msg.target.files[0] })
+                                            if (msg.target.files) {
+                                                ssetInputText({ ...sinputText, "h5": msg.target.files[0].name });
+                                                ssetTmpInputFiles({ ...stmpInputFiles, "h5": msg.target.files[0] })
+                                            }
                                         }} />
                                 </Label>
                             </div>

--- a/src/components/Analysis/index.js
+++ b/src/components/Analysis/index.js
@@ -1712,7 +1712,6 @@ const AnalysisDialog = ({
                                                                                                 gip["subset"]["values"].delete(x);
                                                                                             }
 
-                                                                                            setTmpInputFiles(tmp);
                                                                                             setTmpInputParams(gip);
                                                                                         }}
                                                                                     />

--- a/src/components/Plots/DimPlot.js
+++ b/src/components/Plots/DimPlot.js
@@ -858,10 +858,6 @@ const DimPlot = (props) => {
                 }
                 {showGradient ?
                     <div className='right-sidebar-slider'>
-                        {props?.selectedModality}
-                        {geneColSel[props?.selectedModality]}
-                        {props?.gene}
-                        {genesInfo[geneColSel[props?.selectedModality]][props?.gene]}
                         <Callout>
                             <span>Gradient for <Tag
                                 minimal={true}

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -71,10 +71,12 @@ const AppContextProvider = ({ children }) => {
     batch_correction: {
       method: "none",
       num_neighbors: 15,
+      batch: null
     },
     ann: {
       approximate: true
-    }
+    },
+    subset : null
   });
 
   // which tab is selected ? defaults to new

--- a/src/workers/translate.js
+++ b/src/workers/translate.js
@@ -87,6 +87,7 @@ export function fromUI(inputs, params) {
     };
 
     safeReplace("inputs", "sample_factor", inputs.batch);
+    safeReplace("inputs", "subset", inputs.subset);
 
     for (const [step, spars] of Object.entries(mappings)) {
         for (const [par, target] of Object.entries(spars)) {


### PR DESCRIPTION
- Had to use a table hack to get numeric inputs to sit on the same line.
- Stored `subset` information in `tmpInputFiles[0]` for the time being, to be consistent with `batch`. But maybe it should live in the parameters object instead; it doesn't make a lot of sense to be tied to the first input object.
- Probably should add a little warning when max < min. This is difficult to enforce inside the inputs as it attempts to validate each keystroke, so you can't clear the object and start typing a new number without prematurely hitting the constraint. (Sliders don't work if the min or max value is +/- Inf, and also it's hard to get the appropriate precision.)